### PR TITLE
#4 add an option to disable the opencv preview, drawing the edge and id …

### DIFF
--- a/RobotCode/include/robotVision.h
+++ b/RobotCode/include/robotVision.h
@@ -16,7 +16,9 @@ public:
     RobotVision(int argc, char *argv[]);
     ~RobotVision();
     void loop();
+    void drawDetections(Mat& frame, zarray_t* detections);
 private:
+    bool enableDraw;
     getopt_t *getopt;
     TickMeter meter;
     VideoCapture cap;

--- a/RobotCode/src/robotVision.cpp
+++ b/RobotCode/src/robotVision.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <iomanip>
-#include <opencv2/opencv.hpp>
 #include "robotVision.h"
 
 using namespace std;
@@ -32,7 +31,7 @@ RobotVision::RobotVision(int argc, char *argv[]) {
     // Initialize camera
     cap.open(getopt_get_int(getopt, "camera"));
     if (!cap.isOpened()) {
-        cerr << "Couldn't open video capture device" << endl;
+        printf("Couldn't open video capture device");
         return;
     }
     
@@ -43,7 +42,7 @@ RobotVision::RobotVision(int argc, char *argv[]) {
     apriltag_detector_add_family(td, tf);
 
     if (errno == ENOMEM) {
-        cerr << "Unable to add family to detector due to insufficient memory. Try choosing an alternative tag family.\n";
+        printf("Unable to add family to detector due to insufficient memory. Try choosing an alternative tag family.\n");
         exit(-1);
     }
 
@@ -117,7 +116,7 @@ void RobotVision::loop() {
         errno = 0;
         cap >> frame;
         if (frame.empty()) {
-            cerr << "Failed to capture image" << endl;
+            printf("Failed to capture image");
             break;
         }
 
@@ -129,7 +128,7 @@ void RobotVision::loop() {
         zarray_t *detections = apriltag_detector_detect(td, &im);
 
         if (errno == EAGAIN) {
-            cerr << "Unable to create the " << td->nthreads << " threads requested.\n";
+            printf("Unable to create the %d threads requested.\n", td->nthreads);
             exit(-1);
         }
 

--- a/RobotCode/src/robotVision.cpp
+++ b/RobotCode/src/robotVision.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <iomanip>
-
+#include <opencv2/opencv.hpp>
 #include "robotVision.h"
 
 using namespace std;
@@ -39,12 +39,11 @@ RobotVision::RobotVision(int argc, char *argv[]) {
     // Initialize tag detector with options
     tf = tagStandard52h13_create();
 
-
     td = apriltag_detector_create();
     apriltag_detector_add_family(td, tf);
 
     if (errno == ENOMEM) {
-        printf("Unable to add family to detector due to insufficient memory to allocate the tag-family decoder with the default maximum hamming value of 2. Try choosing an alternative tag family.\n");
+        cerr << "Unable to add family to detector due to insufficient memory. Try choosing an alternative tag family.\n";
         exit(-1);
     }
 
@@ -53,6 +52,8 @@ RobotVision::RobotVision(int argc, char *argv[]) {
     td->nthreads = getopt_get_int(getopt, "threads");
     td->debug = getopt_get_bool(getopt, "debug");
     td->refine_edges = getopt_get_bool(getopt, "refine-edges");
+
+    enableDraw = td->debug && !getopt_get_bool(getopt, "quiet");
 
     meter.stop();
     cout << "Detector for 52h13 initialized in "
@@ -75,11 +76,51 @@ RobotVision::~RobotVision() {
     getopt_destroy(getopt);
 }
 
+void RobotVision::drawDetections(Mat& frame, zarray_t* detections) {
+    if (!enableDraw) {
+        return;
+    }
+
+    for (int i = 0; i < zarray_size(detections); i++) {
+        apriltag_detection_t *det;
+        zarray_get(detections, i, &det);
+        line(frame, Point(det->p[0][0], det->p[0][1]),
+                 Point(det->p[1][0], det->p[1][1]),
+                 Scalar(0, 0xff, 0), 2);
+        line(frame, Point(det->p[0][0], det->p[0][1]),
+                 Point(det->p[3][0], det->p[3][1]),
+                 Scalar(0, 0, 0xff), 2);
+        line(frame, Point(det->p[1][0], det->p[1][1]),
+                 Point(det->p[2][0], det->p[2][1]),
+                 Scalar(0xff, 0, 0), 2);
+        line(frame, Point(det->p[2][0], det->p[2][1]),
+                 Point(det->p[3][0], det->p[3][1]),
+                 Scalar(0xff, 0, 0), 2);
+
+        stringstream ss;
+        ss << det->id;
+        String text = ss.str();
+        int fontface = FONT_HERSHEY_SCRIPT_SIMPLEX;
+        double fontscale = 1.0;
+        int baseline;
+        Size textsize = getTextSize(text, fontface, fontscale, 2, &baseline);
+        putText(frame, text, Point(det->c[0] - textsize.width / 2,
+                                   det->c[1] + textsize.height / 2),
+                fontface, fontscale, Scalar(0xff, 0x99, 0), 2);
+    }
+}
+
 void RobotVision::loop() {
     Mat frame, gray;
+    
     while (true) {
         errno = 0;
         cap >> frame;
+        if (frame.empty()) {
+            cerr << "Failed to capture image" << endl;
+            break;
+        }
+
         cvtColor(frame, gray, COLOR_BGR2GRAY);
 
         // Make an image_u8_t header for the Mat data
@@ -88,44 +129,18 @@ void RobotVision::loop() {
         zarray_t *detections = apriltag_detector_detect(td, &im);
 
         if (errno == EAGAIN) {
-            printf("Unable to create the %d threads requested.\n",td->nthreads);
+            cerr << "Unable to create the " << td->nthreads << " threads requested.\n";
             exit(-1);
         }
 
-        // Draw detection outlines
-        for (int i = 0; i < zarray_size(detections); i++) {
-            apriltag_detection_t *det;
-            zarray_get(detections, i, &det);
-            line(frame, Point(det->p[0][0], det->p[0][1]),
-                     Point(det->p[1][0], det->p[1][1]),
-                     Scalar(0, 0xff, 0), 2);
-            line(frame, Point(det->p[0][0], det->p[0][1]),
-                     Point(det->p[3][0], det->p[3][1]),
-                     Scalar(0, 0, 0xff), 2);
-            line(frame, Point(det->p[1][0], det->p[1][1]),
-                     Point(det->p[2][0], det->p[2][1]),
-                     Scalar(0xff, 0, 0), 2);
-            line(frame, Point(det->p[2][0], det->p[2][1]),
-                     Point(det->p[3][0], det->p[3][1]),
-                     Scalar(0xff, 0, 0), 2);
+        drawDetections(frame, detections);
 
-            stringstream ss;
-            ss << det->id;
-            String text = ss.str();
-            int fontface = FONT_HERSHEY_SCRIPT_SIMPLEX;
-            double fontscale = 1.0;
-            int baseline;
-            Size textsize = getTextSize(text, fontface, fontscale, 2,
-                                            &baseline);
-            putText(frame, text, Point(det->c[0]-textsize.width/2,
-                                       det->c[1]+textsize.height/2),
-                    fontface, fontscale, Scalar(0xff, 0x99, 0), 2);
-        }
         apriltag_detections_destroy(detections);
 
-        imshow("Tag Detections", frame);
-        if (waitKey(30) >= 0)
-            break;
+        if (enableDraw) {
+            imshow("Tag Detections", frame);
+            if (waitKey(30) >= 0)
+                break;
+        }
     }
-
 }

--- a/RobotCode/src/robotVision.cpp
+++ b/RobotCode/src/robotVision.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <iomanip>
 #include "robotVision.h"
+#include "common/getopt.h"
 
 using namespace std;
 using namespace cv;
@@ -21,7 +22,7 @@ RobotVision::RobotVision(int argc, char *argv[]) {
 
     if (!getopt_parse(getopt, argc, argv, 1) ||
             getopt_get_bool(getopt, "help")) {
-        printf("Usage: %s [options]\n", argv[0]);
+        cout << "Usage: " << argv[0] << " [options]\n";
         getopt_do_usage(getopt);
         exit(0);
     }
@@ -29,10 +30,12 @@ RobotVision::RobotVision(int argc, char *argv[]) {
     meter.start();
 
     // Initialize camera
-    cap.open(getopt_get_int(getopt, "camera"));
-    if (!cap.isOpened()) {
-        printf("Couldn't open video capture device");
-        return;
+    if (!getopt_get_bool(getopt, "quiet")) {
+        cap.open(getopt_get_int(getopt, "camera"));
+        if (!cap.isOpened()) {
+            cerr << "Couldn't open video capture device\n";
+            return;
+        }
     }
     
     // Initialize tag detector with options
@@ -42,7 +45,7 @@ RobotVision::RobotVision(int argc, char *argv[]) {
     apriltag_detector_add_family(td, tf);
 
     if (errno == ENOMEM) {
-        printf("Unable to add family to detector due to insufficient memory. Try choosing an alternative tag family.\n");
+        cerr << "Unable to add family to detector due to insufficient memory. Try choosing an alternative tag family.\n";
         exit(-1);
     }
 


### PR DESCRIPTION
Issue #4 
1. Added an enableDraw flag to control whether detection outlines and text are drawn. This reduces unnecessary processing when visual output is not needed.
2. Modified the loop method to skip displaying and waiting operations if enableDraw is false, thus avoiding performance overhead during detection.
3. Included checks for empty frames and improved error messages for better debugging.